### PR TITLE
Change overlapping copy from ::copy_nonoverlapping to ::copy

### DIFF
--- a/src/stream/detail/read.rs
+++ b/src/stream/detail/read.rs
@@ -164,7 +164,7 @@ where
                             }
                             // move forward
                             unsafe {
-                                std::ptr::copy_nonoverlapping(
+                                std::ptr::copy(
                                     buf.as_ptr().add(beg),
                                     buf.as_mut_ptr().add(processed),
                                     data_len,


### PR DESCRIPTION
The ranges passed to this call sometimes overlap. This can be demonstrated with the standard library's debug assertions, which you need to rebuild the standard library in dev/test mode to get:
```
cargo +nightly test -Zbuild-std --target=x86_64-unknown-linux-gnu
```
(or whatever your host is)
You'll get a SIGILL, and running the crashing test program under `gdb` or your favorite debugger can give you a stack trace to this call.
For example:
```
Thread 31 "stream::read::t" received signal SIGILL, Illegal instruction.
[Switching to Thread 0x7fffb7fff640 (LWP 1921151)]
core::intrinsics::copy_nonoverlapping::{closure#0}<u8> () at src/intrinsics.rs:2009
2009	                   ::core::intrinsics::abort();
(gdb) f 3
#3  0x00005555558a8427 in core::intrinsics::copy_nonoverlapping<u8> (src=0x7fffc80012d2, dst=0x7fffc80012d0, count=3)
    at src/intrinsics.rs:2132
2132	       assert_unsafe_precondition!(
(gdb) info args
src = 0x7fffc80012d2
dst = 0x7fffc80012d0
count = 3
```